### PR TITLE
Catdogstodon: Parse post contents

### DIFF
--- a/Userland/Applications/Catdogstodon/CMakeLists.txt
+++ b/Userland/Applications/Catdogstodon/CMakeLists.txt
@@ -9,9 +9,10 @@ compile_gml(Post.gml PostGML.h post_gml)
 set(SOURCES
     main.cpp
     MainWidget.cpp
+    PostContentConversion.cpp
     PostWidget.cpp
     PostGML.h
 )
 
 serenity_bin(Catdogstodon)
-target_link_libraries(Catdogstodon PRIVATE LibCore LibGfx LibGUI LibMain LibProtocol LibImageDecoderClient)
+target_link_libraries(Catdogstodon PRIVATE LibCore LibGfx LibGUI LibMain LibProtocol LibImageDecoderClient LibXML)

--- a/Userland/Applications/Catdogstodon/Post.gml
+++ b/Userland/Applications/Catdogstodon/Post.gml
@@ -2,8 +2,7 @@
     layout: @GUI::VerticalBoxLayout {
         margins: [3]
     }
-
-    fixed_height: 152
+    max_height: "shrink"
 
     // Post bodys
     @GUI::Widget {
@@ -21,10 +20,8 @@
                 name: "profile_picture"
                 bitmap: "/res/icons/32x32/app-catdog.png"
                 // bitmap: "/res/icons/32x32/app-gameoflife.png"
-
                 should_stretch: true
                 auto_resize: false
-
                 fixed_width: 32
                 fixed_height: 32
             }
@@ -52,11 +49,11 @@
         @GUI::Widget {
             layout: @GUI::VerticalBoxLayout {}
 
-            @GUI::Label {
+            @GUI::Widget {
                 name: "content"
-                text: "Well hello friends! :^)"
-                text_alignment: "TopLeft"
-                text_wrapping: "Wrap"
+                layout: @GUI::VerticalBoxLayout {}
+                // FIXME: Change this to a "resize vertically if necessary" computed height once that is supported
+                min_height: 60
             }
 
             @GUI::Label {

--- a/Userland/Applications/Catdogstodon/PostContentConversion.cpp
+++ b/Userland/Applications/Catdogstodon/PostContentConversion.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PostContentConversion.h"
+#include <LibGUI/Label.h>
+#include <LibXML/Parser/Parser.h>
+
+static void print(XML::Node const& node)
+{
+    node.content.visit(
+        [&](XML::Node::Comment const& comment) {
+            dbgln("comment: {}", comment.text);
+        },
+        [&](XML::Node::Text const& text) {
+            dbgln("text: {}", text.builder.to_string());
+        },
+        [&](XML::Node::Element const& element) {
+            dbgln("start element: {}", element.name);
+            for (auto const& attribute : element.attributes) {
+                dbgln("    > {} = {}", attribute.key, attribute.value);
+            }
+            for (auto const& child : element.children)
+                print(child);
+            dbgln("end element: {}", element.name);
+        });
+}
+
+static void extract_text_internal(XML::Node::Element const& node, StringBuilder& builder)
+{
+    for (auto const& child : node.children) {
+        child.content.visit(
+            [&](XML::Node::Comment const&) {
+                // ignore
+            },
+            [&](XML::Node::Text const& text) {
+                builder.append(text.builder.to_string());
+            },
+            [&](XML::Node::Element const& element) {
+                extract_text_internal(element, builder);
+            });
+    }
+}
+
+static String extract_text(XML::Node::Element const& node)
+{
+    StringBuilder builder;
+    extract_text_internal(node, builder);
+    return builder.to_string();
+}
+
+ErrorOr<Vector<NonnullRefPtr<GUI::Widget>>> try_dehtmlify_post_content(StringView html)
+{
+    // We intentionally don't use the LibWeb HTML parser, as that does way too many things for our simple use case.
+    // Just hope that the server sends us XML-valid HTML.
+    XML::Parser parser { html };
+    auto result = parser.parse();
+    if (result.is_error()) {
+        dbgln("Post HTML malformed: {} (offset {})", result.error().error, result.error().offset);
+        return Error::from_string_view("Post HTML malformed"sv);
+    }
+
+    Vector<NonnullRefPtr<GUI::Widget>> widgets;
+
+    auto const document = result.release_value();
+    print(document.root());
+    // FIXME: bad assumption?
+    auto const& containing_paragraph = document.root().content.get<XML::Node::Element>();
+    // FIXME: Do something better than just extracting the text.
+    widgets.append(GUI::Label::construct(extract_text(containing_paragraph)));
+
+    return widgets;
+}

--- a/Userland/Applications/Catdogstodon/PostContentConversion.h
+++ b/Userland/Applications/Catdogstodon/PostContentConversion.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+// Tries to create Serenity GUI text object(s) from the given HTML coming from a post content.
+#include <AK/Forward.h>
+#include <LibGUI/Widget.h>
+
+ErrorOr<Vector<NonnullRefPtr<GUI::Widget>>> try_dehtmlify_post_content(StringView html);

--- a/Userland/Applications/Catdogstodon/PostWidget.h
+++ b/Userland/Applications/Catdogstodon/PostWidget.h
@@ -30,7 +30,7 @@ private:
     RefPtr<GUI::Label> m_account_name;
     RefPtr<GUI::ImageWidget> m_profile_picture;
 
-    RefPtr<GUI::Label> m_content;
+    RefPtr<GUI::Widget> m_content;
     RefPtr<GUI::Label> m_metadata;
 };
 


### PR DESCRIPTION
This uses the existing XML parser and for now only removes all HTML tags to reveal the bare unformatted text. This is enough to ensure that most text-only posts are at least readable.

bonus 1: typo fix around content/metadata

bonus 2: better gml sizing, give posts a larger height for now